### PR TITLE
Add triggers to .github/workflows/

### DIFF
--- a/.github/workflows/BasicSample.yaml
+++ b/.github/workflows/BasicSample.yaml
@@ -1,6 +1,7 @@
 name: BasicSample
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/TwoWaySample.yaml
+++ b/.github/workflows/TwoWaySample.yaml
@@ -1,6 +1,7 @@
 name: TwoWaySample
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/copy-branch.yml
+++ b/.github/workflows/copy-branch.yml
@@ -5,6 +5,7 @@ name: Duplicates main to old master branch
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
 


### PR DESCRIPTION
This PR standardizes GitHub Actions triggers in workflow files within `.github/workflows/`.

The goal is to ensure workflows run consistently on `push`, `pull_request`, and `workflow_dispatch` events where appropriate.

This is part of a batch of pull requests across repositories owned by the `android` organization on GitHub.

**Project Owner:** Please review the changes carefully to ensure they are correct and appropriate for this project before approving and merging.

* If you do not think this change is appropriate (e.g., a workflow should NOT run on one of these triggers), please leave a comment explaining why.
* If you think the goal is appropriate but notice a mistake in the implementation, please leave a comment detailing the mistake.
